### PR TITLE
support for python versions older than 3.10

### DIFF
--- a/gdlevelconverter/conversion/conversionoptions.py
+++ b/gdlevelconverter/conversion/conversionoptions.py
@@ -3,7 +3,7 @@ Defines conversion options class
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 from .gjgameobjectconversiongroups.gjgameobjectconversiongroup \
     import GJGameObjectConversionGroup
@@ -14,5 +14,5 @@ class ConversionOptions:
     """
     Options during full level conversion
     """
-    groups: list[GJGameObjectConversionGroup]
+    groups: List[GJGameObjectConversionGroup]
     maximum_id: Optional[int] = None

--- a/gdlevelconverter/conversion/conversionreport.py
+++ b/gdlevelconverter/conversion/conversionreport.py
@@ -3,7 +3,7 @@ Defines conversion options class
 """
 
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, List, Dict
 
 from .gjgameobjectconversiongroups.gjgameobjectconversiongroup import GJGameObjectConversionGroup
 
@@ -17,7 +17,7 @@ class ConversionReport(Generic[TYPE]):
     """
     Options during full level conversion
     """
-    converted_triggers: list[TYPE]
-    group_conversions: dict[GJGameObjectConversionGroup, list[TYPE]]
-    removed_objects: list[TYPE]
+    converted_triggers: List[TYPE]
+    group_conversions: Dict[GJGameObjectConversionGroup, List[TYPE]]
+    removed_objects: List[TYPE]
     preconversion_object_count: int

--- a/gdlevelconverter/conversion/gjgameobjectconversiongroups/gjgameobjectconversiongroup.py
+++ b/gdlevelconverter/conversion/gjgameobjectconversiongroups/gjgameobjectconversiongroup.py
@@ -3,6 +3,7 @@ Defines the id conversion group class for GJGameObjects
 """
 
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass(frozen=True)
@@ -20,7 +21,7 @@ class GJGameObjectConversionGroup:
     Defines a conversion group
     """
     name: str
-    conversions: list[GJGameObjectConversion]
+    conversions: List[GJGameObjectConversion]
     show_hitbox_warning: bool = False
     show_visual_warning: bool = False
 

--- a/gdlevelconverter/conversion/levelsettingscolorconversions.py
+++ b/gdlevelconverter/conversion/levelsettingscolorconversions.py
@@ -3,7 +3,7 @@ Defines conversions for the colors in level settings
 """
 
 from dataclasses import dataclass
-
+from typing import List
 
 @dataclass(frozen=True)
 class LevelSettingsColorConversion():
@@ -14,7 +14,7 @@ class LevelSettingsColorConversion():
     header_key: str
 
 
-LevelSettingsColorConversions: list[LevelSettingsColorConversion] = [
+LevelSettingsColorConversions: List[LevelSettingsColorConversion] = [
     LevelSettingsColorConversion(1, "color_1"),
     LevelSettingsColorConversion(2, "color_2"),
     LevelSettingsColorConversion(3, "color_3"),

--- a/gdlevelconverter/conversion/triggerobjectcolorconversions.py
+++ b/gdlevelconverter/conversion/triggerobjectcolorconversions.py
@@ -3,6 +3,7 @@ Defines conversions for color triggers to their legacy triggers
 """
 
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass(frozen=True)
@@ -14,7 +15,7 @@ class TriggerObjectColorConversion():
     result_id: int
 
 
-TriggerObjectColorConversions: list[TriggerObjectColorConversion] = [
+TriggerObjectColorConversions: List[TriggerObjectColorConversion] = [
     TriggerObjectColorConversion(1, 221),
     TriggerObjectColorConversion(2, 717),
     TriggerObjectColorConversion(3, 718),

--- a/gdlevelconverter/gjobjects/gjclient.py
+++ b/gdlevelconverter/gjobjects/gjclient.py
@@ -5,7 +5,7 @@ Defines GJClient class
 from dataclasses import dataclass
 import urllib.request
 import urllib.parse
-
+from typing import Dict
 
 @dataclass
 class GJClient:
@@ -20,7 +20,7 @@ class GJClient:
     udid: str = "S-hi-people"
     user_name: str = "21Reupload"
 
-    def make_req(self, url: str, data: dict[str, str]):
+    def make_req(self, url: str, data: Dict[str, str]):
         """
         Makes a post request a url with data
         """

--- a/gdlevelconverter/gjobjects/gjdictionary.py
+++ b/gdlevelconverter/gjobjects/gjdictionary.py
@@ -4,7 +4,7 @@ Functions to aid in conversion to and from a Geometry Dash dictionary type
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, List, Tuple
 
 
 @dataclass
@@ -34,14 +34,14 @@ class ObjectDefinition:
     """
 
 
-def class_from_string(string: str, splitter: str, definitions: list[ObjectDefinition], cls: object):
+def class_from_string(string: str, splitter: str, definitions: List[ObjectDefinition], cls: object):
     """
     parses the special robtop style array
     - expects string like 1,53,2,65,3,14.3
     - returns dict like {'1': '53', '2': '65', '3': '14.3'}
     """
 
-    split_first_step: list[str] = string.split(splitter)
+    split_first_step: List[str] = string.split(splitter)
 
     for index, _value in enumerate(split_first_step):
         # if odd then we on index
@@ -83,7 +83,7 @@ def from_list(splitter: str):
     Used as value in object definition
     Creates a function that converts a list into string using splitter
     """
-    def into_str(obj: list[any]):
+    def into_str(obj: List[any]):
         # gd ends lists with splitter from what i can tell
         return splitter.join([str(x) for x in obj]) + splitter
 
@@ -104,7 +104,7 @@ class GJDictionary:
 
     @property
     @abstractmethod
-    def _definitions(self) -> list[ObjectDefinition]:
+    def _definitions(self) -> List[ObjectDefinition]:
         """
         Defintions for use when converting to/from dictionary
         """
@@ -127,7 +127,7 @@ class GJDictionary:
     def __info_for_key(self, key: str):
         return next((x for x in self._definitions if x.key == key), None)
 
-    def __map_tuple_key_to_index(self, obj: tuple[str, any]):
+    def __map_tuple_key_to_index(self, obj: Tuple[str, any]):
         (key, value) = obj
 
         key_info = self.__info_for_key(key)

--- a/gdlevelconverter/gjobjects/gjgamelevel.py
+++ b/gdlevelconverter/gjobjects/gjgamelevel.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree
 from .gjclient import GJClient
 from .gjlevelstring import GJLevelString
 from . import gjdictionary
+from typing import Dict
 
 
 class GJGameLevel(gjdictionary.GJDictionary):

--- a/gdlevelconverter/gjobjects/gjgameobject.py
+++ b/gdlevelconverter/gjobjects/gjgameobject.py
@@ -2,7 +2,7 @@
 GJGameObject class definition
 """
 
-from typing import Optional
+from typing import Optional, List
 
 from ..conversion import GJGameObjectConversionGroup
 from ..conversion import TriggerObjectColorConversions
@@ -67,7 +67,7 @@ class GJGameObject(gjdictionary.GJDictionary):
 
     def remap_to_legacy_id_by_groups(
         self,
-        groups: list[GJGameObjectConversionGroup]
+        groups: List[GJGameObjectConversionGroup]
     ) -> Optional[GJGameObjectConversionGroup]:
         """
         Remaps the object's id based on the ids defined in groups

--- a/gdlevelconverter/gjobjects/gjlevelsettingsobject.py
+++ b/gdlevelconverter/gjobjects/gjlevelsettingsobject.py
@@ -2,7 +2,7 @@
 Definition for GJLevelSettingsObject
 """
 
-from typing import Optional
+from typing import Optional, List, Dict
 
 from ..conversion import LevelSettingsColorConversions
 from .gjcolorobject import GJColorObject
@@ -50,7 +50,7 @@ class GJLevelSettingsObject(gjdictionary.GJDictionary):
     color_4: Optional[GJColorObject]
     color_3dl: Optional[GJColorObject]
 
-    color_list: Optional[list[GJColorObject]]
+    color_list: Optional[List[GJColorObject]]
 
     def to_legacy_format(self) -> bool:
         """

--- a/gdlevelconverter/gjobjects/gjlevelstring.py
+++ b/gdlevelconverter/gjobjects/gjlevelstring.py
@@ -9,6 +9,7 @@ from ..conversion.conversionoptions import ConversionOptions
 from ..conversion.conversionreport import ConversionReport
 from .gjgameobject import GJGameObject
 from .gjlevelsettingsobject import GJLevelSettingsObject
+from typing import List
 
 
 class GJLevelString:
@@ -18,7 +19,7 @@ class GJLevelString:
     OBJECT_SEPARATOR: str = ";"
 
     header: GJLevelSettingsObject
-    objects: list[GJGameObject]
+    objects: List[GJGameObject]
 
     def __init__(self, level):
         object_strings = level.split(self.OBJECT_SEPARATOR)

--- a/tests/testgjdictionary.py
+++ b/tests/testgjdictionary.py
@@ -5,6 +5,7 @@ Defines GJDictionary test cases using a test object
 import unittest
 
 from gdlevelconverter.gjobjects import gjdictionary
+from typing import List
 
 
 class GJTestObject(gjdictionary.GJDictionary):
@@ -27,7 +28,7 @@ class GJTestObject(gjdictionary.GJDictionary):
 
     title: str
 
-    names: list[str]
+    names: List[str]
 
 
 class TestGJDictionary(unittest.TestCase):


### PR DESCRIPTION
`list[T]` was only added in 3.10, so replace those with types from typing